### PR TITLE
Makes the mariadb keepalive respect user credentials

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
         env_file:
             - .env
         healthcheck:
-            test: ['CMD', 'mysqladmin', 'ping', '-h', '127.0.0.1']
+            test: ['CMD', 'mysqladmin', 'ping', '-h', '127.0.0.1', '-u', $MYSQL_USER, '-p', $MYSQL_PASSWORD]
             interval: 1m30s
             timeout: 30s
             retries: 10


### PR DESCRIPTION
99% of times developer configures auth for the database. Without providing user & password for the ping it fails and spams logs with unsuccessful attempts.

## What I did

Made the keepalive script take username & pwd from the container environment and use it for the pings.

## How I did it

Provided environment names containing username and password for the ping command.

## How to verify it

1. check that the mariadb container spams with message `symfony-mariadb | 2018-12-18  8:41:40 140507825699560 [Warning] Access denied for user 'root'@'localhost' (using password: NO)` when running without these changes;
2. check that there are no logs like this when this change is applied.

## Description for the change log

Made the mariadb keepalive logic to use user credentials for connecting to the database.
